### PR TITLE
chore: Update `publish.bat` to use `geode index mods update` and chec…

### DIFF
--- a/publish.bat
+++ b/publish.bat
@@ -1,6 +1,6 @@
 cls
 @echo off
 @REM Execute the index submit command
-geode index submit create
+geode index mods update 
 @REM Message to the user
-echo Index creation submitted. Please check the status of the index creation using the command "geode index status".
+echo Index creation submitted. Please check the status of the index creation using the command "geode index mods pending".


### PR DESCRIPTION
This pull request updates the index submission workflow in the `publish.bat` script to use the newer `mods update` command instead of the previous `submit create` command. The user instructions have also been updated to reference the correct status command.

Workflow update:

* Changed the index submission command from `geode index submit create` to `geode index mods update` in `publish.bat`.
* Updated the user message to instruct checking status with `geode index mods pending` instead of `geode index status`