### PR TITLE
Dev geode 2.207

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # 1.4.1
-- Added garage preview support (toggleable)
+- Added garage preview support
+- Added profile icon mod support and compatibility
 
 # 1.4.0
 - Fixed the flashPlayer wich was making the icon white permanently

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # 1.4.1
 - Added garage preview support
 - Added profile icon mod support and compatibility
+- Added rainbow effect to profile icons and fixed glow in garage
+
 
 # 1.4.0
 - Fixed the flashPlayer wich was making the icon white permanently

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 1.4.1
+- Added garage preview support (toggleable)
+
 # 1.4.0
 - Fixed the flashPlayer wich was making the icon white permanently
 

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 		"mac": "2.2074",
 		"ios": "2.2074"
 	},
-	"version": "1.4.1-beta.2",
+	"version": "1.4.1",
 	"id": "saumondeluxe.rainbow_icon",
 	"name": "Rainbow Icon",
 	"developer": "SaumonDeLuxe",

--- a/mod.json
+++ b/mod.json
@@ -63,6 +63,12 @@
 			"description": "Enable or disable the rainbow effect in the garage/icon kit.",
 			"default": true
 		},
+		"profileEnable": {
+			"name": "Rainbow in Profile",
+			"type": "bool",
+			"description": "Enable or disable the rainbow effect on the icons in the profile page.",
+			"default": true
+		},
 		"menuEnable": {
 			"name": "Rainbow in Menu",
 			"type": "bool",

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 		"mac": "2.2074",
 		"ios": "2.2074"
 	},
-	"version": "1.4.0",
+	"version": "1.4.1-beta",
 	"id": "saumondeluxe.rainbow_icon",
 	"name": "Rainbow Icon",
 	"developer": "SaumonDeLuxe",
@@ -55,6 +55,12 @@
 			"name": "Enable Rainbow Icon in Editor",
 			"type": "bool",
 			"description": "Enable or disable the rainbow effect on your icons in the editor.",
+			"default": true
+		},
+		"garagePreview": {
+			"name": "Rainbow in Garage",
+			"type": "bool",
+			"description": "Enable or disable the rainbow effect in the garage/icon kit.",
 			"default": true
 		},
 		"shortcut": {

--- a/mod.json
+++ b/mod.json
@@ -63,6 +63,12 @@
 			"description": "Enable or disable the rainbow effect in the garage/icon kit.",
 			"default": true
 		},
+		"menuEnable": {
+			"name": "Rainbow in Menu",
+			"type": "bool",
+			"description": "Enable or disable the rainbow effect on the profile icon in the main menu.",
+			"default": true
+		},
 		"shortcut": {
 			"name": "Rainbow Shortcut",
 			"type": "bool",

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
 		"mac": "2.2074",
 		"ios": "2.2074"
 	},
-	"version": "1.4.1-beta",
+	"version": "1.4.1-beta.2",
 	"id": "saumondeluxe.rainbow_icon",
 	"name": "Rainbow Icon",
 	"developer": "SaumonDeLuxe",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include <Geode/modify/PauseLayer.hpp>
 #include <Geode/modify/EditorPauseLayer.hpp>
 #include <Geode/modify/MenuLayer.hpp>
+#include <Geode/modify/GJGarageLayer.hpp>
+#include <Geode/binding/SimplePlayer.hpp>
 #include <Geode/utils/web.hpp>
 #include <chrono>
 #include <functional>
@@ -158,6 +160,46 @@ void applyRainbowColors(PlayerObject* player, bool isPlayer1, RainbowSettings& s
     }
 }
 
+// Helper function to apply colors to a SimplePlayer (for Garage)
+void applyRainbowColorsSimple(SimplePlayer* player, bool isPlayer1, RainbowSettings& settings, const cocos2d::_ccColor3B& mainColor, const cocos2d::_ccColor3B& invertedColor) {
+    if (!player) return;
+
+    int64_t playerPreset = settings.playerPreset;
+    bool applyToThisPlayer = (playerPreset == 1) || (isPlayer1 && playerPreset == 2) || (!isPlayer1 && playerPreset == 3);
+
+    if (!applyToThisPlayer) return;
+
+    auto gm = GameManager::sharedState();
+
+    // Apply Player Colors based on preset
+    // SimplePlayer usually treats setColor as the primary color and setSecondColor as secondary.
+    // However, we need to be careful with how SimplePlayer logic works.
+    
+    if (settings.preset == 1) // Both colors
+    {
+        player->setColor(mainColor);
+        player->setSecondColor(settings.sync ? mainColor : invertedColor);
+    }
+    else if (settings.preset == 2) // Primary color only
+    {
+        player->setColor(mainColor);
+        player->setSecondColor(gm->colorForIdx(gm->getPlayerColor2()));
+    }
+    else if (settings.preset == 3) // Secondary color only
+    {
+        player->setColor(gm->colorForIdx(gm->getPlayerColor()));
+        player->setSecondColor(mainColor);
+    }
+
+    // SimplePlayer might support glow, usually via setGlowOutline
+    if (settings.glow) {
+         player->setGlowOutline(settings.sync ? mainColor : invertedColor);
+    }
+    
+    // Explicitly update colors to ensure changes take effect immediately
+    player->updateColors();
+}
+
 // Helper function to update hue
 void updateHue(const RainbowSettings& settings) {
      if (g_hue >= 360)
@@ -170,7 +212,6 @@ void updateHue(const RainbowSettings& settings) {
         g_hue += settings.superSpeed ? 10.0f : static_cast<float>(settings.speed) / 10.0f;
     }
 }
-
 
 class $modify(PlayerObject)
 {
@@ -302,4 +343,108 @@ class $modify(OpenSettings, PauseLayer)
              }
         }
     };
+};
+
+class $modify(MyGarageLayer, GJGarageLayer) {
+    bool init() {
+        if (!GJGarageLayer::init()) return false;
+        
+        geode::log::info("MyGarageLayer::init called - Hook is working!");
+        
+        // Use a custom selector to avoid potential conflicts or suppression of the default update
+        this->schedule(schedule_selector(MyGarageLayer::rainbowUpdate));
+        return true;
+    }
+
+    void rainbowUpdate(float dt) {
+        // No need to call GJGarageLayer::update(dt) here as we are a separate schedule
+        
+        // Throttle logging to avoid spam
+        static int logCounter = 0;
+        bool doLog = (logCounter++ % 180) == 0; // Log roughly every 3 seconds (60fps)
+
+        auto settings = getModSettings();
+        
+        if (doLog) {
+             geode::log::info("MyGarageLayer::rainbowUpdate - Enable: {}, Preset: {}", settings.enable, settings.preset);
+        }
+
+        if (!settings.enable) return;
+
+        updateHue(settings); 
+
+        if (settings.pastel)
+        {
+            settings.saturation = 50;
+            settings.brightness = 90;
+        }
+
+        auto mainColorP1 = getRainbow(settings.offset_color_p1, settings.saturation, settings.brightness);
+        auto invertedColorP1 = getRainbow(settings.offset_color_p1 + 180, settings.saturation, settings.brightness);
+        
+        SimplePlayer* player = m_playerObject;
+        if (!player) {
+            player = typeinfo_cast<SimplePlayer*>(this->getChildByID("player-icon"));
+        }
+
+        if (player) {
+             if (doLog) {
+                geode::log::info("GaragePlayer Found: {}", player);
+             }
+
+            // User info: "Color 1 node" contains Glow [0] and Secondary [2].
+            // We assume "Color 1 node" is one of the direct children of SimplePlayer.
+            // We will iterate ALL direct children and treat them as potential "Color 1 nodes".
+            
+            auto children = player->getChildren();
+            if (children) {
+                for (int i = 0; i < children->count(); ++i) {
+                    auto mainNode = static_cast<CCNode*>(children->objectAtIndex(i));
+                    auto mainSprite = typeinfo_cast<CCSprite*>(mainNode);
+                    
+                    if (mainSprite) {
+                        // 1. This is "Color 1" (Parent Node). Apply Main Color.
+                        mainSprite->setColor(mainColorP1);
+                        
+                        // 2. Check its children for Glow [0] and Secondary [2]
+                        if (mainSprite->getChildrenCount() > 0) {
+                             auto subChildren = mainSprite->getChildren();
+                             if (doLog && i == 0) geode::log::info("SubChild Count for Child 0: {}", subChildren->count());
+
+                             // Child [0] -> Glow
+                             if (settings.glow && subChildren->count() > 0) {
+                                 auto glowNode = static_cast<CCNode*>(subChildren->objectAtIndex(0));
+                                 if (auto glowSprite = typeinfo_cast<CCSprite*>(glowNode)) {
+                                     glowSprite->setColor(settings.sync ? mainColorP1 : invertedColorP1);
+                                 }
+                             }
+                             
+                             // Child [2] -> Secondary
+                             if (subChildren->count() > 2) {
+                                 auto secNode = static_cast<CCNode*>(subChildren->objectAtIndex(2));
+                                 if (auto secSprite = typeinfo_cast<CCSprite*>(secNode)) {
+                                      // Secondary Logic
+                                      ccColor3B secondaryColor;
+                                      if (settings.preset == 0 || settings.preset == 1) // Both
+                                          secondaryColor = settings.sync ? mainColorP1 : invertedColorP1;
+                                      else if (settings.preset == 3) // Secondary only (Main is rainbow)
+                                          secondaryColor = mainColorP1;
+                                      else 
+                                          secondaryColor = GameManager::sharedState()->colorForIdx(GameManager::sharedState()->getPlayerColor2());
+
+                                      if (settings.preset == 0 || settings.preset == 1 || settings.preset == 3) {
+                                           secSprite->setColor(secondaryColor);
+                                      }
+                                 }
+                             }
+                        }
+                    }
+                }
+            }
+            
+             player->updateColors();
+        } else {
+            if (doLog) geode::log::info("GaragePlayer NOT FOUND");
+        }
+    }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,27 +33,29 @@ struct RainbowSettings {
     bool superSpeed;
     bool pastel;
     bool editorEnable; // Added for editor specific enable
+    bool garagePreview;
 };
 
 // Fetches all settings at once
 RainbowSettings getModSettings() {
+    RainbowSettings settings;
     auto mod = Mod::get();
-    return {
-        mod->getSettingValue<double>("speed"),
-        mod->getSettingValue<double>("saturation"),
-        mod->getSettingValue<double>("brightness"),
-        mod->getSettingValue<int64_t>("offset_color_p1"),
-        mod->getSettingValue<int64_t>("offset_color_p2"),
-        mod->getSettingValue<bool>("enable"),
-        mod->getSettingValue<bool>("glow"),
-        mod->getSettingValue<int64_t>("preset"),
-        mod->getSettingValue<int64_t>("playerPreset"),
-        mod->getSettingValue<bool>("sync"),
-        mod->getSettingValue<bool>("wave"),
-        mod->getSettingValue<bool>("superSpeed"),
-        mod->getSettingValue<bool>("pastel"),
-        mod->getSettingValue<bool>("editorEnable") // Fetch editor setting
-    };
+    settings.speed = mod->getSettingValue<double>("speed");
+    settings.saturation = mod->getSettingValue<double>("saturation");
+    settings.brightness = mod->getSettingValue<double>("brightness");
+    settings.offset_color_p1 = mod->getSettingValue<int64_t>("offset_color_p1");
+    settings.offset_color_p2 = mod->getSettingValue<int64_t>("offset_color_p2");
+    settings.enable = mod->getSettingValue<bool>("enable");
+    settings.glow = mod->getSettingValue<bool>("glow");
+    settings.preset = mod->getSettingValue<int64_t>("preset");
+    settings.playerPreset = mod->getSettingValue<int64_t>("playerPreset");
+    settings.sync = mod->getSettingValue<bool>("sync");
+    settings.wave = mod->getSettingValue<bool>("wave");
+    settings.pastel = mod->getSettingValue<bool>("pastel");
+    settings.superSpeed = mod->getSettingValue<bool>("superSpeed");
+    settings.editorEnable = mod->getSettingValue<bool>("editorEnable"); // Fetch editor setting
+    settings.garagePreview = mod->getSettingValue<bool>("garagePreview");
+    return settings;
 }
 
 
@@ -346,11 +348,31 @@ class $modify(OpenSettings, PauseLayer)
 };
 
 class $modify(MyGarageLayer, GJGarageLayer) {
+    void onSettings(CCObject*) {
+        geode::openSettingsPopup(Mod::get());
+    }
+
     bool init() {
         if (!GJGarageLayer::init()) return false;
         
         geode::log::info("MyGarageLayer::init called - Hook is working!");
         
+        // Add settings button to shards-menu if shortcut is enabled
+        if (Mod::get()->getSettingValue<bool>("shortcut")) {
+            auto menu = this->getChildByID("shards-menu");
+            if (menu) {
+                auto btnSprite = CCSprite::create("btnSprite.png"_spr);
+                if (btnSprite) {
+                    auto btn = CCMenuItemSpriteExtra::create(
+                        btnSprite, this, menu_selector(MyGarageLayer::onSettings)
+                    );
+                    btn->setID("rainbow-settings-button"_spr);
+                    menu->addChild(btn);
+                    menu->updateLayout();
+                }
+            }
+        }
+
         // Use a custom selector to avoid potential conflicts or suppression of the default update
         this->schedule(schedule_selector(MyGarageLayer::rainbowUpdate));
         return true;
@@ -366,10 +388,10 @@ class $modify(MyGarageLayer, GJGarageLayer) {
         auto settings = getModSettings();
         
         if (doLog) {
-             geode::log::info("MyGarageLayer::rainbowUpdate - Enable: {}, Preset: {}", settings.enable, settings.preset);
+             geode::log::info("MyGarageLayer::rainbowUpdate - Enable: {}, GaragePreview: {}", settings.enable, settings.garagePreview);
         }
 
-        if (!settings.enable) return;
+        if (!settings.enable || !settings.garagePreview) return;
 
         updateHue(settings); 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <Geode/modify/EditorPauseLayer.hpp>
 #include <Geode/modify/MenuLayer.hpp>
 #include <Geode/modify/GJGarageLayer.hpp>
+#include <Geode/modify/ProfilePage.hpp>
 #include <Geode/binding/SimplePlayer.hpp>
 #include <Geode/utils/web.hpp>
 #include <chrono>
@@ -35,6 +36,7 @@ struct RainbowSettings {
     bool editorEnable; // Added for editor specific enable
     bool garagePreview;
     bool menuEnable;
+    bool profileEnable;
 };
 
 // Fetches all settings at once
@@ -57,6 +59,7 @@ RainbowSettings getModSettings() {
     settings.editorEnable = mod->getSettingValue<bool>("editorEnable"); // Fetch editor setting
     settings.garagePreview = mod->getSettingValue<bool>("garagePreview");
     settings.menuEnable = mod->getSettingValue<bool>("menuEnable");
+    settings.profileEnable = mod->getSettingValue<bool>("profileEnable");
     return settings;
 }
 
@@ -387,7 +390,6 @@ class $modify(MyMenuLayer, MenuLayer) {
         if (!btn) return;
 
         // "profile-icon" is likely the normal image of the button, or a child of it if the structure is complex.
-        // User said: "renferme un CCSprite profile-icon".
         // Let's look for child by ID just to be safe, or check the NormalImage.
         // CCMenuItemSpriteExtra's normal image is usually a CCSprite but not always named.
         // However, if the mod sets IDs, we can look for it.
@@ -395,7 +397,6 @@ class $modify(MyMenuLayer, MenuLayer) {
         CCNode* iconNode = btn->getChildByID("profile-icon");
         if (!iconNode) {
             // Fallback: Check NormalImage if ID finding fails, though user specified ID.
-            // But user said "renferme", so it's a child.
              auto normalImg = btn->getNormalImage();
              if (normalImg && std::string(normalImg->getID()) == "profile-icon") {
                  iconNode = normalImg;
@@ -446,6 +447,148 @@ class $modify(MyMenuLayer, MenuLayer) {
             }
             
             player->updateColors();
+        }
+    }
+};
+
+class $modify(MyProfilePage, ProfilePage) {
+    bool init(int accountID, bool ownProfile) {
+        if (!ProfilePage::init(accountID, ownProfile)) return false;
+
+        this->schedule(schedule_selector(MyProfilePage::updateProfileRainbow));
+        return true;
+    }
+
+    void updateProfileRainbow(float dt) {
+        static int logCounter = 0;
+        bool doLog = (logCounter++ % 180) == 0; 
+        
+        auto settings = getModSettings();
+        if (!settings.enable || !settings.profileEnable) return;
+
+        updateHue(settings);
+
+        if (settings.pastel) {
+            settings.saturation = 50;
+            settings.brightness = 90;
+        }
+
+        auto mainColor = getRainbow(settings.offset_color_p1, settings.saturation, settings.brightness);
+        auto invertedColor = getRainbow(settings.offset_color_p1 + 180, settings.saturation, settings.brightness);
+
+        CCNode* menu = nullptr;
+        auto children = this->getChildren();
+        
+        if (children) {
+            for (int i = 0; i < children->count(); ++i) {
+                auto child = static_cast<CCNode*>(children->objectAtIndex(i));
+                if (typeinfo_cast<CCLayer*>(child)) {
+                    auto potentialMenu = child->getChildByID("player-menu");
+                    if (potentialMenu) {
+                        menu = potentialMenu;
+                        if (doLog) geode::log::info("ProfilePage: Found 'player-menu' in child layer {}, ID: {}", i, child->getID());
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!menu) {
+             if (doLog) {
+                 geode::log::info("ProfilePage: 'player-menu' not found in any child layer");
+                 if (children) {
+                     for (int i = 0; i < children->count(); ++i) {
+                         auto child = static_cast<CCNode*>(children->objectAtIndex(i));
+                         geode::log::info("ProfilePage Child {}: ID='{}', Type={}", i, child->getID(), typeid(*child).name());
+                     }
+                 }
+             }
+             return;
+        }
+
+        auto menuChildren = menu->getChildren();
+        if (!menuChildren) {
+             if (doLog) geode::log::info("ProfilePage: 'player-menu' has no children");
+             return;
+        }
+        
+        if (doLog) geode::log::info("ProfilePage: 'player-menu' child count: {}", menuChildren->count());
+
+        for (int i = 0; i < menuChildren->count(); ++i) {
+             auto node = static_cast<CCNode*>(menuChildren->objectAtIndex(i));
+             
+             // Find SimplePlayer in the node
+             SimplePlayer* player = nullptr;
+             auto nodeChildren = node->getChildren();
+             if (nodeChildren) {
+                 for (int j = 0; j < nodeChildren->count(); ++j) {
+                     auto child = static_cast<CCNode*>(nodeChildren->objectAtIndex(j));
+                     player = typeinfo_cast<SimplePlayer*>(child);
+                     if (player) break;
+                 }
+             }
+
+             if (player) {
+                  // applyRainbowColorsSimple(player, true, settings, mainColor, invertedColor); // Replaced with manual logic below
+                  
+                  auto playerChildren = player->getChildren();
+                  if (playerChildren) {
+                    for (int k = 0; k < playerChildren->count(); ++k) {
+                        auto mainNode = static_cast<CCNode*>(playerChildren->objectAtIndex(k));
+                        auto mainSprite = typeinfo_cast<CCSprite*>(mainNode);
+                        
+                        if (mainSprite) {
+                            // 1. Main Color
+                            mainSprite->setColor(mainColor);
+                            
+                            // 2. Children: Glow [0], Secondary [2]
+                            if (mainSprite->getChildrenCount() > 0) {
+                                 auto subChildren = mainSprite->getChildren();
+                                 
+                                 // Child [0] -> Glow
+                                 if (settings.glow && subChildren->count() > 0) {
+                                     auto glowNode = static_cast<CCNode*>(subChildren->objectAtIndex(0));
+                                     if (auto glowSprite = typeinfo_cast<CCSprite*>(glowNode)) {
+                                         glowSprite->setColor(settings.sync ? mainColor : invertedColor);
+                                     }
+                                 }
+                                 
+                                 // Child [2] -> Secondary
+                                 if (subChildren->count() > 2) {
+                                     auto secNode = static_cast<CCNode*>(subChildren->objectAtIndex(2));
+                                     if (auto secSprite = typeinfo_cast<CCSprite*>(secNode)) {
+                                          // Secondary Logic
+                                          ccColor3B secondaryColor;
+                                          if (settings.preset == 0 || settings.preset == 1) // Both
+                                              secondaryColor = settings.sync ? mainColor : invertedColor;
+                                          else if (settings.preset == 3) // Secondary only
+                                              secondaryColor = mainColor;
+                                          else 
+                                              secondaryColor = GameManager::sharedState()->colorForIdx(GameManager::sharedState()->getPlayerColor2()); // Fallback to normal color 2
+                                          
+                                          // Note: ProfilePage icons might use specific colors from the user profile being viewed, 
+                                          // but finding that specific user's color 2 might be complex. 
+                                          // For now, if we are rainbow-ing, we use the rainbow color.
+                                          // If we fall back (preset 2), we might be setting it to 'GameManager's color 2' which is the logged in user's color.
+                                          // This might be incorrect if looking at ANOTHER user's profile.
+                                          // But for the purpose of "Rainbow Icon", we usually overwrite the color anyway.
+                                          
+                                          if (settings.preset == 0 || settings.preset == 1 || settings.preset == 3) {
+                                               secSprite->setColor(secondaryColor);
+                                          }
+                                     }
+                                 }
+                            }
+                        }
+                    }
+                  }
+                  
+                  // Still call updateColors to handle other states/ensuring strictness if possible
+                  player->updateColors();
+
+             } else {
+                 if (doLog) geode::log::info("ProfilePage: SimplePlayer not found in child {}", i);
+             }
         }
     }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -347,6 +347,107 @@ class $modify(OpenSettings, PauseLayer)
     };
 };
 
+class $modify(MyMenuLayer, MenuLayer) {
+    bool init() {
+        if (!MenuLayer::init()) return false;
+        
+        if (Loader::get()->isModLoaded("capeling.icon_profile")) {
+            geode::log::info("Rainbow Icon: 'capeling.icon_profile' is LOADED");
+            this->schedule(schedule_selector(MyMenuLayer::updateProfileRainbow));
+        }
+        
+        return true;
+    }
+
+    void updateProfileRainbow(float dt) {
+        auto settings = getModSettings();
+        if (!settings.enable) return;
+
+        // Note: Global hue is updated in PlayLayer/Editor/Garage. 
+        // In MenuLayer, we might need to update it ourselves if it's not running elsewhere?
+        // But usually updateHue is called in general loops. 
+        // Let's call it here just in case, it's safe (time based).
+        updateHue(settings);
+
+        if (settings.pastel) {
+            settings.saturation = 50;
+            settings.brightness = 90;
+        }
+        
+        auto mainColor = getRainbow(settings.offset_color_p1, settings.saturation, settings.brightness);
+        auto invertedColor = getRainbow(settings.offset_color_p1 + 180, settings.saturation, settings.brightness);
+
+        // Hierarchy: profile-menu -> profile-button -> profile-icon -> SimplePlayer
+        auto menu = this->getChildByID("profile-menu");
+        if (!menu) return;
+
+        auto btn = static_cast<CCMenuItemSpriteExtra*>(menu->getChildByID("profile-button"));
+        if (!btn) return;
+
+        // "profile-icon" is likely the normal image of the button, or a child of it if the structure is complex.
+        // User said: "renferme un CCSprite profile-icon".
+        // Let's look for child by ID just to be safe, or check the NormalImage.
+        // CCMenuItemSpriteExtra's normal image is usually a CCSprite but not always named.
+        // However, if the mod sets IDs, we can look for it.
+        
+        CCNode* iconNode = btn->getChildByID("profile-icon");
+        if (!iconNode) {
+            // Fallback: Check NormalImage if ID finding fails, though user specified ID.
+            // But user said "renferme", so it's a child.
+             auto normalImg = btn->getNormalImage();
+             if (normalImg && std::string(normalImg->getID()) == "profile-icon") {
+                 iconNode = normalImg;
+             }
+        }
+
+        if (!iconNode) return;
+
+        // Now find SimplePlayer inside profile-icon
+        // It might be a direct child.
+        SimplePlayer* player = nullptr;
+        
+        // Try finding by type helper if possible, or iterate children
+        auto children = iconNode->getChildren();
+        if (children) {
+            for (int i=0; i<children->count(); ++i) {
+                auto child = static_cast<CCNode*>(children->objectAtIndex(i));
+                player = typeinfo_cast<SimplePlayer*>(child);
+                if (player) break;
+            }
+        }
+
+        if (player) {
+            // Re-use logic for color application
+            // Similar to Garage logic: Apply main color to player and handle children for GLOW/Secondary
+            
+            player->setColor(mainColor);
+            
+            // NOTE: SimplePlayer in menus often works correctly with setSecondColor/updateColors
+            // unlike the Garage one which needed manual brute-forcing. 
+            // We'll try standard methods first.
+            
+             // Apply Player Colors based on preset
+            auto gm = GameManager::sharedState();
+            ccColor3B secondaryColor;
+             
+            if (settings.preset == 0 || settings.preset == 1) // Both
+                secondaryColor = settings.sync ? mainColor : invertedColor;
+            else if (settings.preset == 3) // Secondary only
+                secondaryColor = mainColor;
+            else 
+                secondaryColor = gm->colorForIdx(gm->getPlayerColor2());
+
+            player->setSecondColor(secondaryColor);
+
+            if (settings.glow) {
+                player->setGlowOutline(settings.sync ? mainColor : invertedColor);
+            }
+            
+            player->updateColors();
+        }
+    }
+};
+
 class $modify(MyGarageLayer, GJGarageLayer) {
     void onSettings(CCObject*) {
         geode::openSettingsPopup(Mod::get());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@ struct RainbowSettings {
     bool pastel;
     bool editorEnable; // Added for editor specific enable
     bool garagePreview;
+    bool menuEnable;
 };
 
 // Fetches all settings at once
@@ -55,6 +56,7 @@ RainbowSettings getModSettings() {
     settings.superSpeed = mod->getSettingValue<bool>("superSpeed");
     settings.editorEnable = mod->getSettingValue<bool>("editorEnable"); // Fetch editor setting
     settings.garagePreview = mod->getSettingValue<bool>("garagePreview");
+    settings.menuEnable = mod->getSettingValue<bool>("menuEnable");
     return settings;
 }
 
@@ -361,7 +363,7 @@ class $modify(MyMenuLayer, MenuLayer) {
 
     void updateProfileRainbow(float dt) {
         auto settings = getModSettings();
-        if (!settings.enable) return;
+        if (!settings.enable || !settings.menuEnable) return;
 
         // Note: Global hue is updated in PlayLayer/Editor/Garage. 
         // In MenuLayer, we might need to update it ourselves if it's not running elsewhere?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,8 +529,14 @@ class $modify(MyProfilePage, ProfilePage) {
              }
 
              if (player) {
-                  // applyRainbowColorsSimple(player, true, settings, mainColor, invertedColor); // Replaced with manual logic below
-                  
+                  // Move updateColors to BEFORE manual changes so we don't overwrite them
+                  player->updateColors();
+
+                  // Explicitly set glow outline using the helper method if available (most robust)
+                  if (settings.glow) {
+                       player->setGlowOutline(settings.sync ? mainColor : invertedColor);
+                  }
+
                   auto playerChildren = player->getChildren();
                   if (playerChildren) {
                     for (int k = 0; k < playerChildren->count(); ++k) {
@@ -541,15 +547,19 @@ class $modify(MyProfilePage, ProfilePage) {
                             // 1. Main Color
                             mainSprite->setColor(mainColor);
                             
-                            // 2. Children: Glow [0], Secondary [2]
-                            if (mainSprite->getChildrenCount() > 0) {
-                                 auto subChildren = mainSprite->getChildren();
-                                 
+                            // 2. Children loop
+                            auto subChildren = mainSprite->getChildren();
+                            if (subChildren) {
+                                 if (doLog && k == 0) geode::log::info("ProfilePage Player Child {}: SubChildren Count: {}", k, subChildren->count());
+
                                  // Child [0] -> Glow
+                                 // Even if setGlowOutline is called, we can try to force it here too just in case
                                  if (settings.glow && subChildren->count() > 0) {
                                      auto glowNode = static_cast<CCNode*>(subChildren->objectAtIndex(0));
                                      if (auto glowSprite = typeinfo_cast<CCSprite*>(glowNode)) {
                                          glowSprite->setColor(settings.sync ? mainColor : invertedColor);
+                                     } else {
+                                         if (doLog) geode::log::info("ProfilePage: Child 0 is NOT CCSprite");
                                      }
                                  }
                                  
@@ -557,34 +567,25 @@ class $modify(MyProfilePage, ProfilePage) {
                                  if (subChildren->count() > 2) {
                                      auto secNode = static_cast<CCNode*>(subChildren->objectAtIndex(2));
                                      if (auto secSprite = typeinfo_cast<CCSprite*>(secNode)) {
-                                          // Secondary Logic
                                           ccColor3B secondaryColor;
                                           if (settings.preset == 0 || settings.preset == 1) // Both
                                               secondaryColor = settings.sync ? mainColor : invertedColor;
                                           else if (settings.preset == 3) // Secondary only
                                               secondaryColor = mainColor;
                                           else 
-                                              secondaryColor = GameManager::sharedState()->colorForIdx(GameManager::sharedState()->getPlayerColor2()); // Fallback to normal color 2
-                                          
-                                          // Note: ProfilePage icons might use specific colors from the user profile being viewed, 
-                                          // but finding that specific user's color 2 might be complex. 
-                                          // For now, if we are rainbow-ing, we use the rainbow color.
-                                          // If we fall back (preset 2), we might be setting it to 'GameManager's color 2' which is the logged in user's color.
-                                          // This might be incorrect if looking at ANOTHER user's profile.
-                                          // But for the purpose of "Rainbow Icon", we usually overwrite the color anyway.
-                                          
+                                              secondaryColor = GameManager::sharedState()->colorForIdx(GameManager::sharedState()->getPlayerColor2());
+
                                           if (settings.preset == 0 || settings.preset == 1 || settings.preset == 3) {
                                                secSprite->setColor(secondaryColor);
                                           }
+                                     } else {
+                                          if (doLog) geode::log::info("ProfilePage: Child 2 is NOT CCSprite");
                                      }
                                  }
                             }
                         }
                     }
                   }
-                  
-                  // Still call updateColors to handle other states/ensuring strictness if possible
-                  player->updateColors();
 
              } else {
                  if (doLog) geode::log::info("ProfilePage: SimplePlayer not found in child {}", i);
@@ -664,6 +665,14 @@ class $modify(MyGarageLayer, GJGarageLayer) {
             // We assume "Color 1 node" is one of the direct children of SimplePlayer.
             // We will iterate ALL direct children and treat them as potential "Color 1 nodes".
             
+            // Move updateColors to BEFORE manual changes so we don't overwrite them
+            player->updateColors();
+
+             // Explicitly set glow outline using the helper method if available (most robust)
+            if (settings.glow) {
+                 player->setGlowOutline(settings.sync ? mainColorP1 : invertedColorP1);
+            }
+
             auto children = player->getChildren();
             if (children) {
                 for (int i = 0; i < children->count(); ++i) {
@@ -710,7 +719,6 @@ class $modify(MyGarageLayer, GJGarageLayer) {
                 }
             }
             
-             player->updateColors();
         } else {
             if (doLog) geode::log::info("GaragePlayer NOT FOUND");
         }


### PR DESCRIPTION
This pull request updates the mod to version 1.4.1, introducing new features and improvements related to profile icon customization and compatibility. The main changes include support for garage preview, enhanced profile icon mod compatibility, and new options for enabling the rainbow effect in various parts of the UI.

Feature additions and enhancements:

* Added support for rainbow effect in the garage preview, with a new `garagePreview` option in `mod.json` to enable or disable this feature. [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R6) [[2]](diffhunk://#diff-667da15ba24e05778924a37d15988f81d593a3cd71b5cf17af835094aef6b0efR60-R77)
* Added compatibility and support for profile icon mods, including a new `profileEnable` option to control the rainbow effect on profile icons. [[1]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R6) [[2]](diffhunk://#diff-667da15ba24e05778924a37d15988f81d593a3cd71b5cf17af835094aef6b0efR60-R77)
* Introduced a `menuEnable` option to allow toggling the rainbow effect on the profile icon in the main menu.

Bug fixes and improvements:

* Fixed the glow effect for profile icons in the garage.

Version update:

* Updated the mod version to `1.4.1` in `mod.json` and documented the changes in `changelog.md`. [[1]](diffhunk://#diff-667da15ba24e05778924a37d15988f81d593a3cd71b5cf17af835094aef6b0efL9-R9) [[2]](diffhunk://#diff-3bd14d078188074c410028847113ceae68865d0ad5b844a27183ef87fbe2fcc3R1-R6)