### PR TITLE
fix: Restrict push trigger to release branches in workflow configuration

### DIFF
--- a/.github/workflows/mod.yml
+++ b/.github/workflows/mod.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - "release-*"
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the workflow trigger configuration in `.github/workflows/mod.yml` to restrict CI runs on push events to only branches matching the `release-*` pattern.

Workflow configuration update:

* Changed the `push` trigger to only run on branches named `release-*` instead of all branches in `.github/workflows/mod.yml`.