### PR TITLE
feat: Réorganiser l'application de la couleur de la traînée ondulée p…

### DIFF
--- a/src/color_apply.cpp
+++ b/src/color_apply.cpp
@@ -11,12 +11,6 @@ void applyRainbowColors(PlayerObject *player, bool isPlayer1, RainbowSettings &s
     if (!applyToThisPlayer)
         return;
 
-    // Apply Wave Trail Color
-    if (settings.wave && player->m_waveTrail)
-    {
-        player->m_waveTrail->setColor(mainColor);
-    }
-
     auto gm = GameManager::sharedState();
 
     // Apply Player Colors based on preset
@@ -34,6 +28,20 @@ void applyRainbowColors(PlayerObject *player, bool isPlayer1, RainbowSettings &s
     {
         player->setColor(gm->colorForIdx(gm->getPlayerColor()));
         player->setSecondColor(mainColor);
+    }
+
+    // Apply Wave Trail Color
+    if (player->m_waveTrail)
+    {
+        if (settings.wave)
+        {
+            player->m_waveTrail->setColor(mainColor);
+        }
+        else
+        {
+            ccColor3B normalColor = gm->colorForIdx(isPlayer1 ? gm->getPlayerColor() : gm->getPlayerColor2());
+            player->m_waveTrail->setColor(normalColor);
+        }
     }
 
     // Apply Glow Color


### PR DESCRIPTION
This pull request updates the logic for applying rainbow colors to a player's wave trail in the `applyRainbowColors` function. The main improvement is that the wave trail color is now always set, either to the rainbow color or to the player's normal color, depending on the `settings.wave` flag.

**Wave trail color application improvements:**

* The wave trail color is now always set: if `settings.wave` is true, it uses the rainbow color; otherwise, it resets to the player's normal color. This ensures the wave trail color is never left in an unintended state. (`src/color_apply.cpp`, [src/color_apply.cppR33-R46](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941R33-R46))
* The previous logic, which only set the wave trail color when `settings.wave` was true and did not reset it otherwise, has been removed to prevent inconsistent coloring. (`src/color_apply.cpp`, [src/color_apply.cppL14-L19](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941L14-L19))