### PR TITLE
Dev geode 2.208

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 1.5.1
+- Fixed glow outline bug with flashing effect
+
 # 1.5.0
 - Remade the mod with better code and better performance (nerdy stuff)
 - Fixed Garage preview and profile icon support for presets

--- a/mod.json
+++ b/mod.json
@@ -1,12 +1,12 @@
 {
-	"geode": "5.3.0",
+	"geode": "5.7.1",
 	"gd": {
 		"win": "2.2081",
 		"android": "2.2081",
 		"ios": "2.2081",
 		"mac":"2.2081"
 	},
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"id": "saumondeluxe.rainbow_icon",
 	"name": "Rainbow Icon",
 	"developer": "SaumonDeLuxe",

--- a/mod.json
+++ b/mod.json
@@ -102,6 +102,12 @@
 			"description": "Enable or disable the wave effect on the rainbow.",
 			"default": true
 		},
+		"streak": {
+			"name": "Rainbow Hardstreak",
+			"type": "bool",
+			"description": "Enable or disable the rainbow effect on the hardstreak trail behind the icon.",
+			"default": true
+		},
 		"offset_color_p1": {
 			"type": "int",
 			"name": "Rainbow Offset Color Player 1",
@@ -138,9 +144,9 @@
 		"preset": {
 			"name": "Rainbow Preset",
 			"type": "int",
-			"description": "0 = Only Glow(if enabled), 1 = All enabled, 2 = Only the color1 rainbow effect, 3 = Only the color2 rainbow effect",
+			"description": "0 = Only Glow (if enabled), 1 = All enabled, 2 = Only color1 rainbow, 3 = Only color2 rainbow, 4 = Only Glow and Trail (icon colors stay normal)",
 			"default": 1,
-			"max": 3,
+			"max": 4,
 			"min": 0,
 			"control": {
 				"arrows": true,

--- a/src/color_apply.cpp
+++ b/src/color_apply.cpp
@@ -14,7 +14,12 @@ void applyRainbowColors(PlayerObject *player, bool isPlayer1, RainbowSettings &s
     auto gm = GameManager::sharedState();
 
     // Apply Player Colors based on preset
-    if (settings.preset == 1) // Both colors
+    if (settings.preset == 0) // Glow only - restore normal colors so flashPlayer doesn't leave the icon white
+    {
+        player->setColor(gm->colorForIdx(gm->getPlayerColor()));
+        player->setSecondColor(gm->colorForIdx(gm->getPlayerColor2()));
+    }
+    else if (settings.preset == 1) // Both colors
     {
         player->setColor(mainColor);
         player->setSecondColor(settings.sync ? mainColor : invertedColor);
@@ -65,7 +70,12 @@ void applyRainbowColorsSimple(SimplePlayer *player, bool isPlayer1, RainbowSetti
 
     auto gm = GameManager::sharedState();
 
-    if (settings.preset == 1) // Both colors
+    if (settings.preset == 0) // Glow only - restore normal colors so flashPlayer doesn't leave the icon white
+    {
+        player->setColor(gm->colorForIdx(gm->getPlayerColor()));
+        player->setSecondColor(gm->colorForIdx(gm->getPlayerColor2()));
+    }
+    else if (settings.preset == 1) // Both colors
     {
         player->setColor(mainColor);
         player->setSecondColor(settings.sync ? mainColor : invertedColor);

--- a/src/color_apply.cpp
+++ b/src/color_apply.cpp
@@ -34,6 +34,11 @@ void applyRainbowColors(PlayerObject *player, bool isPlayer1, RainbowSettings &s
         player->setColor(gm->colorForIdx(gm->getPlayerColor()));
         player->setSecondColor(mainColor);
     }
+    else if (settings.preset == 4) // Glow and Trail only - restore normal icon colors, glow/wave trail still get rainbow
+    {
+        player->setColor(gm->colorForIdx(gm->getPlayerColor()));
+        player->setSecondColor(gm->colorForIdx(gm->getPlayerColor2()));
+    }
 
     // Apply Wave Trail Color
     if (player->m_waveTrail)
@@ -89,6 +94,11 @@ void applyRainbowColorsSimple(SimplePlayer *player, bool isPlayer1, RainbowSetti
     {
         player->setColor(gm->colorForIdx(gm->getPlayerColor()));
         player->setSecondColor(mainColor);
+    }
+    else if (settings.preset == 4) // Glow and Trail only - restore normal icon colors, glow/wave trail still get rainbow
+    {
+        player->setColor(gm->colorForIdx(gm->getPlayerColor()));
+        player->setSecondColor(gm->colorForIdx(gm->getPlayerColor2()));
     }
 
     if (settings.glow)


### PR DESCRIPTION
This pull request updates the Rainbow Icon mod to version 1.5.1, introducing a bug fix for the glow outline, new customization options, and enhancements to the preset system. The main changes include a fix for the glow outline flashing bug, a new option for enabling the rainbow effect on the hardstreak trail, and an expanded preset system with updated logic to support additional configurations.

**Bug Fixes:**
* Fixed a bug where the glow outline would flash incorrectly.

**New Features and Enhancements:**
* Added a new `streak` option to enable or disable the rainbow effect on the hardstreak trail behind the icon in `mod.json`.
* Expanded the `preset` configuration to include a new mode (value 4) that enables only glow and trail rainbow effects, with icon colors remaining normal. Updated the description and increased the maximum value to 4 in `mod.json`.
* Updated logic in `applyRainbowColors` and `applyRainbowColorsSimple` to handle the new preset modes, ensuring correct color application for each preset, including restoring normal icon colors for specific presets. [[1]](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941L17-R22) [[2]](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941R37-R41) [[3]](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941L68-R83) [[4]](diffhunk://#diff-682ff720856686fe916d8ea5678672b42d4bd3449938f763cecbad48d5a2f941R98-R102)

**Version and Dependency Updates:**
* Bumped mod version to 1.5.1 and updated the required `geode` version from 5.3.0 to 5.7.1 in `mod.json`.